### PR TITLE
Add option to use URL as a source

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.2",
         "twig/extensions": "~1.0",
-        "data-uri/data-uri": "~0.1.0"
+        "data-uri/data-uri": "~0.2.0"
     },
     "autoload": {
         "psr-0": {

--- a/src/DataURI/TwigExtension.php
+++ b/src/DataURI/TwigExtension.php
@@ -112,6 +112,9 @@ class TwigExtension extends \Twig_Extension
      */
     protected function getDataFromScalar($source, $strict, $mime, $parameters)
     {
+        if (filter_var($source, FILTER_VALIDATE_URL) !== false) {
+            return Data::buildFromUrl($source, $strict);
+        }
 
         if (file_exists($source)) {
             return Data::buildFromFile($source, $strict);

--- a/tests/src/DataUri/TwigExtensionTest.php
+++ b/tests/src/DataUri/TwigExtensionTest.php
@@ -91,6 +91,16 @@ class TwigExtensionTest extends \PHPUnit_Framework_TestCase
      * @covers DataUri\TwigExtension::dataUri
      * @covers DataUri\TwigExtension::getDataFromScalar
      */
+    public function testDataUriUrl()
+    {
+        $url = 'http://www.alchemy.fr/images/header_03.png';
+        $this->twig->render('{{ url | dataUri(false) }}', array('url' => $url));
+    }
+
+    /**
+     * @covers DataUri\TwigExtension::dataUri
+     * @covers DataUri\TwigExtension::getDataFromScalar
+     */
     public function testDataUriFileStrict()
     {
         $data = $this->twig->render('{{ file | dataUri(false) }}', array('file' => __DIR__ . '/../../photo01.JPG'));


### PR DESCRIPTION
With this change, you can pass a remote URL as the scalar source for the image. 

Important: it relies on this change: https://github.com/alchemy-fr/PHP-dataURI/pull/5. At the moment, it hasn't been released yet, so I expect this PR shall have to wait until we can define the new version dependency.

Meanwhile, you can review the PR and let me know if there is something to add and/or fix.

Thank you!