### PR TITLE
Updated deprecated Twig calls. Fixed spelling issues.

### DIFF
--- a/src/DataURI/TwigExtension.php
+++ b/src/DataURI/TwigExtension.php
@@ -11,7 +11,7 @@ namespace DataURI;
 
 /**
  * Twig extension for data URI, see README for example of use
- * Converts datas to the data URI Url scheme
+ * Converts data to the data URI Url scheme
  *
  * @see https://www.ietf.org/rfc/rfc2397.txt
  */
@@ -29,12 +29,12 @@ class TwigExtension extends \Twig_Extension
 
     /**
      *
-     * @return type
+     * @return array
      */
     public function getFilters()
     {
         return array(
-            'dataUri' => new \Twig_Filter_Method($this, 'dataUri'),
+            'dataUri' => new \Twig_SimpleFilter($this, 'dataUri'),
         );
     }
 
@@ -54,7 +54,7 @@ class TwigExtension extends \Twig_Extension
             switch (true) {
                 case is_resource($source):
 
-                    $data = $this->getDataFromRessource($source, $strict, $mime, $parameters);
+                    $data = $this->getDataFromResource($source, $strict, $mime, $parameters);
 
                     break;
                 case is_scalar($source):
@@ -81,22 +81,22 @@ class TwigExtension extends \Twig_Extension
 
     /**
      *
-     * @param ressource     $source
+     * @param resource     $source
      * @param boolean       $strict
      * @param string        $mime
      * @param array         $parameters
      * @return \DataURI\Data
      */
-    protected function getDataFromRessource($source, $strict, $mime, Array $parameters)
+    protected function getDataFromResource($source, $strict, $mime, Array $parameters)
     {
 
-        $streamDatas = null;
+        $streamData = null;
 
         while ( ! feof($source)) {
-            $streamDatas .= fread($source, 8192);
+            $streamData .= fread($source, 8192);
         }
 
-        $data =  new Data($streamDatas, $mime, $parameters, $strict);
+        $data =  new Data($streamData, $mime, $parameters, $strict);
         $data->setBinaryData(true);
 
         return $data;

--- a/tests/src/DataUri/TwigExtensionTest.php
+++ b/tests/src/DataUri/TwigExtensionTest.php
@@ -11,7 +11,7 @@ class TwigExtensionTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $loader = new \Twig_Loader_String();
+        $loader = new \Twig_Loader_Array(array());
         $this->extension = new TwigExtension();
         $this->twig = new \Twig_Environment($loader);
         $this->twig->addExtension($this->extension);
@@ -33,19 +33,19 @@ class TwigExtensionTest extends \PHPUnit_Framework_TestCase
         $filters = $this->extension->getFilters();
         $this->assertArrayHasKey('dataUri', $filters);
         $method = $filters['dataUri'];
-        $this->assertInstanceOf('\\Twig_Filter_Method', $method);
+        $this->assertInstanceOf('\\Twig_SimpleFilter', $method);
     }
 
     /**
      * @covers DataUri\TwigExtension::dataUri
-     * @covers DataUri\TwigExtension::getDataFromRessource
+     * @covers DataUri\TwigExtension::getDataFromResource
      */
-    public function testDataUriRessource()
+    public function testDataUriResource()
     {
         $file = __DIR__ . '/../../smile.png';
-        $ressource = fopen($file, 'r');
+        $resource = fopen($file, 'r');
 
-        $data = $this->twig->render('{{ file | dataUri(false, "image/jpeg") }}', array('file' => $ressource));
+        $data = $this->twig->render('{{ file | dataUri(false, "image/jpeg") }}', array('file' => $resource));
         $this->assertEquals('data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAAB'
             . 'AAAAAQCAMAAAAoLQ9TAAAAyVBMVEUzM2a9pUL90Bzi0phoZH3/6pb/9cytooiEg'
             . '3v93FhST2vuwhL977qVjGr/++z/1zl0cILPvoj/5X9eW3Xix1/9ywP/7aX/+NyL'


### PR DESCRIPTION
Hi,

I updated the Twig_Filter_Method which is now deprecated and marked for removal for Twig 2.0.
I also fixed some spelling issues (mainly in PHPDoc type hints).

Regards,

Nicolas